### PR TITLE
adding task to update /etc/hosts if required

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,8 @@ domain: "localdomain"
 zmpasswd: "!23Change"
 zmnetwork: "192.168.200.0/8"
 timezone: UTC
+#hosts_lines:
+#  - "198.162.1.3 {{ hostname }}.{{ domain }} {{ hostname }}" 
 
 #
 # Zimbra configuration

--- a/tasks/install/zimbra.yml
+++ b/tasks/install/zimbra.yml
@@ -2,6 +2,15 @@
 #
 # Download and install Zimbra OSE
 ################################################################################
+
+- name: Update /etc/hosts
+  lineinfile:
+    path: /etc/hosts 
+    line: "{{ item }}" 
+    state: present
+  with_items: "{{ hosts_lines }}"
+  when: hosts_lines is defined
+  
 - name: Download and unpacking Zimbra OSE
   unarchive:
     validate_certs: no


### PR DESCRIPTION
In some cases ([like split dns](https://wiki.zimbra.com/wiki/Split_DNS) you need a line to resolve the IP of `mail.yourdomain.com` to the private IP of the zimbra server) it is necessary to modify the `/ etc / hosts`  file, so that the `zimbra` installation does not fail.
I know that you modify the file with your role [baseline role](https://github.com/lucascbeyeler/baseline/blob/cba9d06ae6be04924e4a6d928cccaea230681094/tasks/main.yml#L69), but I think it would be nice to have the option in this one.

thanks!