### PR TITLE
Disable existing DNS stub listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Role Variables
 * **zmlogoapp:** Inform the path for your logo (Application Screen) - don't inform and no image will be applied;
 * **timezone:** inform the timezone the playbook should set in your server;
 * **zimbra_version:** Inform which version of Zimbra you want to install. Default: 8.8.15
+* **disable_existing_dns_stub_listener:** Inform "y" to disable the systemd-resolved DNS stub listener and free up port 53. Default: **n**
 
 Service Variables - Inform "y" or "n"
 --------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,3 +45,4 @@ timezone: UTC
 ################################################################################
 zimbra_version: 8.8.15
 
+disable_existing_dns_stub_listener: n

--- a/tasks/configure/disable_existing_dns_stub_listener.yml
+++ b/tasks/configure/disable_existing_dns_stub_listener.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Deshabilitar resolvedor local
+- name: Disable local resolver
   ansible.builtin.ini_file:
     path: /etc/systemd/resolved.conf
     section: Resolve
@@ -8,20 +8,20 @@
     value: "no"
   register: disable_dns_stub_listener
 
-- name: Destruir enlace simbólico
+- name: Delete symbolic link
   file:
     path: /etc/resolv.conf
     state: absent
   when: disable_dns_stub_listener.changed
 
-- name: Crear enlace simbólico
+- name: Create symbolic link
   file:
     path: /etc/resolv.conf
     src: /run/systemd/resolve/resolv.conf
     state: link
   when: disable_dns_stub_listener.changed
 
-- name: Reiniciar servicio systemd-resolved
+- name: Restart systemd-resolved service
   ansible.builtin.service:
     name: systemd-resolved
     state: restarted

--- a/tasks/configure/dnscache.yml
+++ b/tasks/configure/dnscache.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Deshabilitar resolvedor local
+  ansible.builtin.ini_file:
+    path: /etc/systemd/resolved.conf
+    section: Resolve
+    option: DNSStubListener
+    value: "no"
+  register: disable_dns_stub_listener
+
+- name: Destruir enlace simbólico
+  file:
+    path: /etc/resolv.conf
+    state: absent
+  when: disable_dns_stub_listener.changed
+
+- name: Crear enlace simbólico
+  file:
+    path: /etc/resolv.conf
+    src: /run/systemd/resolve/resolv.conf
+    state: link
+  when: disable_dns_stub_listener.changed
+
+- name: Reiniciar servicio systemd-resolved
+  ansible.builtin.service:
+    name: systemd-resolved
+    state: restarted
+  when: disable_dns_stub_listener.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,8 @@
   when: zimbra_store == 'y'
 - import_tasks: 'configure/mta.yml'
   when: zimbra_mta == 'y'
-- import_tasks: 'configure/dnscache.yml'
-  when: zimbra_dnscache == 'y'
+- import_tasks: 'configure/disable_existing_dns_stub_listener.yml'
+  when: zimbra_dnscache == 'y' and disable_existing_dns_stub_listener == 'y'
 
 #
 # Extras configuration process

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,8 @@
   when: zimbra_store == 'y'
 - import_tasks: 'configure/mta.yml'
   when: zimbra_mta == 'y'
+- import_tasks: 'configure/dnscache.yml'
+  when: zimbra_dnscache == 'y'
 
 #
 # Extras configuration process


### PR DESCRIPTION
This PR proposes the posibility to disable the systemd-resolved DNS stub listener and free up port 53.